### PR TITLE
Add missing java serialization to application.conf

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,6 +1,7 @@
 akka {
   loglevel = DEBUG
   actor {
+    allow-java-serialization = on
     debug {
       receive = on
       fsm = on


### PR DESCRIPTION
PR dodaje brakującą opcję do application.conf, pozwalając na uzywanie serializacji Javy. Bez tego persystencja (przynajmniej u mnie) nie działa i ćwiczenie wysypuje się 

Widziałem że w lab-5 ta opcja jest już uwzględniona, więc jeśli to celowe działanie mające na celu zmuszenie nas do zapoznania się z application.conf, to usunę PR :smile: 