### PR TITLE
Make sure gzip loads in UTF-8

### DIFF
--- a/src/main/scala/EShop/lab5/ProductCatalogApp.scala
+++ b/src/main/scala/EShop/lab5/ProductCatalogApp.scala
@@ -16,7 +16,7 @@ class SearchService() {
     getClass.getResourceAsStream("/query_result.gz")
   )
   private[lab5] val brandItemsMap = Source
-    .fromInputStream(gz)
+    .fromInputStream(gz)("UTF-8")
     .getLines()
     .drop(1) //skip header
     .filter(_.split(",").length >= 3)


### PR DESCRIPTION
Prosty fix na prosty problem. Zdarza się, że domyślnym charsetem nie jest UTF-8, przez co 'toList' rzuca Exception bez tej poprawki.