### PR TITLE
Fix scalafmt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ project/plugins/project/
 .worksheet
 .idea
 .bloop
+.bsp
 .metals
 metals.sbt
 .vscode

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,10 +1,11 @@
+version = "3.0.6"
 style = defaultWithAlign
 maxColumn = 120
 
 continuationIndent.callSite = 2
 continuationIndent.defnSite = 2
 continuationIndent.extendSite = 2
-danglingParentheses = true
+danglingParentheses.preset = true
 
 newlines {
   sometimesBeforeColonInMethodReturnType = false
@@ -17,7 +18,7 @@ align {
   openParenDefnSite = false
 }
 
-docstrings = JavaDoc
+docstrings.style = Asterisk
 
 rewrite {
   rules = [SortImports, RedundantBraces]

--- a/build.sbt
+++ b/build.sbt
@@ -14,6 +14,3 @@ libraryDependencies ++= Seq(
   "org.scalatest"     %% "scalatest"                % "3.2.9" % "test",
   "ch.qos.logback"    % "logback-classic"           % "1.2.6"
 )
-
-// scalaFmt
-scalafmtOnCompile := true

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.3")


### PR DESCRIPTION
- added explicit `version` to the `.scalafmt.conf` and fixed existing configuration errors. If `version` is not specified metals always asks the user about one, without it formatting in the editor won't work.
- removed `scalafmtOnCompile` as this option is [discouraged](https://scalameta.org/scalafmt/docs/installation.html#format-on-compile). Instead, `sbt scalafmtAll` can be used to format codebase.
- one may use build server different than bloop - hence ignored `.bsp` directory.