### PR TITLE
Prevent from swapping arguments in actor commands

### DIFF
--- a/src/main/scala/EShop/lab3/OrderManager.scala
+++ b/src/main/scala/EShop/lab3/OrderManager.scala
@@ -6,15 +6,20 @@ import akka.actor.typed.{ActorRef, Behavior}
 
 object OrderManager {
 
+  case class ItemId(value: String)         extends AnyVal
+  case class DeliveryMethod(value: String) extends AnyVal
+  case class PaymentMethod(value: String)  extends AnyVal
+
   sealed trait Command
-  case class AddItem(id: String, sender: ActorRef[Ack])                                               extends Command
-  case class RemoveItem(id: String, sender: ActorRef[Ack])                                            extends Command
-  case class SelectDeliveryAndPaymentMethod(delivery: String, payment: String, sender: ActorRef[Ack]) extends Command
-  case class Buy(sender: ActorRef[Ack])                                                               extends Command
-  case class Pay(sender: ActorRef[Ack])                                                               extends Command
-  case class ConfirmCheckoutStarted(checkoutRef: ActorRef[TypedCheckout.Command])                     extends Command
-  case class ConfirmPaymentStarted(paymentRef: ActorRef[Payment.Command])                             extends Command
-  case object ConfirmPaymentReceived                                                                  extends Command
+  case class AddItem(id: ItemId, sender: ActorRef[Ack])    extends Command
+  case class RemoveItem(id: String, sender: ActorRef[Ack]) extends Command
+  case class SelectDeliveryAndPaymentMethod(delivery: DeliveryMethod, payment: PaymentMethod, sender: ActorRef[Ack])
+    extends Command
+  case class Buy(sender: ActorRef[Ack])                                           extends Command
+  case class Pay(sender: ActorRef[Ack])                                           extends Command
+  case class ConfirmCheckoutStarted(checkoutRef: ActorRef[TypedCheckout.Command]) extends Command
+  case class ConfirmPaymentStarted(paymentRef: ActorRef[Payment.Command])         extends Command
+  case object ConfirmPaymentReceived                                              extends Command
 
   sealed trait Ack
   case object Done extends Ack //trivial ACK

--- a/src/test/scala/EShop/lab3/OrderManagerIntegrationTest.scala
+++ b/src/test/scala/EShop/lab3/OrderManagerIntegrationTest.scala
@@ -34,11 +34,11 @@ class OrderManagerIntegrationTest
   it should "supervise whole order process" in {
     val orderManager = testKit.spawn(new OrderManager().start).ref
 
-    sendMessage(orderManager, AddItem("rollerblades", _))
+    sendMessage(orderManager, AddItem(ItemId("rollerblades"), _))
 
     sendMessage(orderManager, Buy)
 
-    sendMessage(orderManager, SelectDeliveryAndPaymentMethod("paypal", "inpost", _))
+    sendMessage(orderManager, SelectDeliveryAndPaymentMethod(DeliveryMethod("inpost"), PaymentMethod("paypal"), _))
 
     sendMessage(orderManager, ref => Pay(ref))
   }


### PR DESCRIPTION
Previously, it was very easy to swap arguments in `SelectDeliveryAndPaymentMethod` because they were plain strings, and it happened in `OrderManagerIntegrationTest`.
Now, thanks to value classes & compiler, mixing order is much harder than before.