### PR TITLE
Valid root Behavior in ProductCatalogApp

### DIFF
--- a/src/main/scala/EShop/lab5/ProductCatalogApp.scala
+++ b/src/main/scala/EShop/lab5/ProductCatalogApp.scala
@@ -76,7 +76,7 @@ object ProductCatalogApp extends App {
   private val config = ConfigFactory.load()
 
   private val productCatalogSystem = ActorSystem[Nothing](
-    Behaviors.same,
+    Behaviors.empty,
     "ProductCatalog",
     config.getConfig("productcatalog").withFallback(config)
   )


### PR DESCRIPTION
Currently ProductCatalogApp tries to create ActorSystem with root behavior "Same" which results in `java.lang.IllegalArgumentException: cannot use Same as initial behavior` on application start. Akka sources says that neither `Behaviors.same` nor `Behaviours.unhandled` can be use as valid inital state. It probably should be replaced with `Behaviors.empty`.