### PR TITLE
Enable forking only in test scope

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,4 +35,4 @@ libraryDependencies += "io.gatling"            % "gatling-test-framework"    % "
 // scalaFmt
 scalafmtOnCompile := true
 
-fork := true
+Test / fork := true


### PR DESCRIPTION
I observed locally that the http server is shutting down immediately after start. The server stopped immediately and I didn't press RETURN to stop.

```
[info] Press RETURN to stop...
[info] 23:39:17.106 [ClusterWorkRouters-akka.actor.default-dispatcher-25] INFO akka.cluster.Cluster - Cluster Node [akka://ClusterWorkRouters@127.0.0.1:53220] - Shutting down...
[info] 23:39:17.106 [ClusterWorkRouters-akka.actor.default-dispatcher-25] INFO akka.cluster.Cluster - Cluster Node [akka://ClusterWorkRouters@127.0.0.1:53220] - Successfully shut down
```

It seems to me that this server was just launched on the new jvm  and therefore there was no access to the `StdIn`. So, `StdIn.readLine()` return `null`.

So, in this piece of [code](https://github.com/agh-reactive/reactive-scala-labs-templates/blob/7d1480908e9a38fa957c47a01ff9ad9ed6982a26/src/main/scala/EShop/lab6/WorkHttpClusterApp.scala#L123),  there will be no waiting for press RETURN to stop because `StdIn.readLine()` return immediately `null`.


I think the fork flag should only be set in scope `Test`. For `Main`, this can cause the problem described above.