### PR TITLE
Update github CI to stop using deprecated actions

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -12,10 +12,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
-        java-version: 1.8
+        distribution: 'adopt'
+        java-version: '17'
     - name: Run tests
       run: sbt test

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up JDK 1.8
+    - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
         distribution: 'adopt'


### PR DESCRIPTION
Currently the CI pipeline has 2 issiues:
1. It shows the following warning when ran: 
```
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2, actions/checkout@v1.
```
This can be resolved by using higher versions of `actions/checkout` and `actions/setup-java`.

2. It fails to run the testing suite, because of the following error:
```
Error:  [SECURITY][10/24/2023 09:41:33.507] [CheckoutTest-akka.actor.default-dispatcher-6] [akka.actor.ActorSystemImpl(CheckoutTest)] Uncaught error from thread [CheckoutTest-akka.actor.default-dispatcher-6]: ch/qos/logback/classic/spi/LogbackServiceProvider has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0, shutting down JVM since 'akka.jvm-exit-on-fatal-error' is enabled for ActorSystem[CheckoutTest]
```
This issue can be fixed by using a higher java version - the one proposed in this PR is java 17.